### PR TITLE
Fix tooltip persistence on info icon hover

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -122,6 +122,7 @@
       
       /// CITATION ///
 
+      const infoIconContainer = document.getElementById("info-icon-container");
       const infoTooltip = document.getElementById("info-tooltip");
       infoTooltip.innerHTML = `
         <p>Models adapted from the Allen Human Reference Atlas – 3D (2020), Version 1.0.0.</p>
@@ -168,6 +169,25 @@
           </a>
         </p>
       `;
+
+      const showInfoTooltip = () => {
+        infoIconContainer.classList.add("info-tooltip-visible");
+      };
+
+      const hideInfoTooltip = () => {
+        infoIconContainer.classList.remove("info-tooltip-visible");
+      };
+
+      infoIconContainer.addEventListener("mouseenter", showInfoTooltip);
+      infoIconContainer.addEventListener("mouseleave", hideInfoTooltip);
+      infoIconContainer.addEventListener("focusin", showInfoTooltip);
+      infoIconContainer.addEventListener("focusout", (event) => {
+        if (event.relatedTarget && infoIconContainer.contains(event.relatedTarget)) {
+          return;
+        }
+
+        hideInfoTooltip();
+      });
 
       /// NAVIGATION BAR ///
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -560,9 +560,9 @@ input:checked + .checkbox-button:before {
         top: -0.25rem;
         left: 150%;
         z-index: 99;
-        transform: translateX(-8%) translateY(-100%) scale(0);
+        transform: translateX(-8%) translateY(-100%) scale(0.95);
         transform-origin: bottom left;
-        transition: 150ms transform;
+        transition: 150ms transform, 150ms opacity, 150ms visibility;
         background: var(--grey-tertiary);
         color: var(--white);
         border-radius: var(--border-radius);
@@ -573,13 +573,17 @@ input:checked + .checkbox-button:before {
         pointer-events: none;
         white-space: normal;
         line-height: 1.4;
+        opacity: 0;
+        visibility: hidden;
 }
 
-#info-icon-container:hover .info-tooltip,
+#info-icon-container.info-tooltip-visible .info-tooltip,
 #info-icon-container:focus .info-tooltip,
 #info-icon-container:focus-within .info-tooltip {
         transform: translateX(-8%) translateY(-100%) scale(1);
         pointer-events: auto;
+        opacity: 1;
+        visibility: visible;
 }
 
 .info-tooltip::after {


### PR DESCRIPTION
## Summary
- keep the info tooltip visible while hovering either the icon or the tooltip so links remain clickable
- update tooltip styling to support the new visibility class and smooth transitions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dac9e9e6388331bd69d08269c478b0