### PR TITLE
Keep info tooltip active while hovering popup

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -123,6 +123,7 @@
       /// CITATION ///
 
       const infoTooltip = document.getElementById("info-tooltip");
+      const infoIconContainer = document.getElementById("info-icon-container");
       infoTooltip.innerHTML = `
         <p>Models adapted from the Allen Human Reference Atlas – 3D (2020), Version 1.0.0.</p>
         <p><strong>Dataset citation:</strong></p>
@@ -168,6 +169,29 @@
           </a>
         </p>
       `;
+
+      let tooltipHideTimeout;
+
+      function showInfoTooltip() {
+        clearTimeout(tooltipHideTimeout);
+        infoTooltip.classList.add("visible");
+      }
+
+      function hideInfoTooltip() {
+        clearTimeout(tooltipHideTimeout);
+        tooltipHideTimeout = setTimeout(() => {
+          if (!infoIconContainer.matches(":focus-within")) {
+            infoTooltip.classList.remove("visible");
+          }
+        }, 50);
+      }
+
+      infoIconContainer.addEventListener("mouseenter", showInfoTooltip);
+      infoIconContainer.addEventListener("mouseleave", hideInfoTooltip);
+      infoIconContainer.addEventListener("focusin", showInfoTooltip);
+      infoIconContainer.addEventListener("focusout", hideInfoTooltip);
+      infoTooltip.addEventListener("mouseenter", showInfoTooltip);
+      infoTooltip.addEventListener("mouseleave", hideInfoTooltip);
 
       /// NAVIGATION BAR ///
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -582,6 +582,11 @@ input:checked + .checkbox-button:before {
         pointer-events: auto;
 }
 
+.info-tooltip.visible {
+        transform: translateX(-8%) translateY(-100%) scale(1);
+        pointer-events: auto;
+}
+
 .info-tooltip::after {
         content: "";
         position: absolute;


### PR DESCRIPTION
## Summary
- ensure the info tooltip stays open while hovering over the icon or tooltip content so links remain clickable
- add a visible state to the tooltip styling so it only closes after leaving the popup entirely

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dac9e9e6388331bd69d08269c478b0