### PR TITLE
Add embryonic origin details to region info panel

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -638,10 +638,18 @@ function showRegionInfoPanel(regionId, hemisphere, regionInfo) {
       ? regionInfo.aliases
       : regionInfo?.keywords;
   const groups = normalizeToArray(regionInfo?.groups);
+  const embryonicOrigin =
+    typeof regionInfo?.embryonic_origin === "string"
+      ? regionInfo.embryonic_origin.trim()
+      : "";
 
   const descriptionSection = description
     ? `<p class="region-info-description">${description}</p>`
     : `<p class="region-info-placeholder">No description available.</p>`;
+
+  const embryonicOriginSection = embryonicOrigin
+    ? `<div class="region-info-section"><h4>Embryonic Origin</h4><p class="region-info-embryonic-origin">${embryonicOrigin}</p></div>`
+    : `<div class="region-info-section"><h4>Embryonic Origin</h4><p class="region-info-placeholder">No embryonic origin information available.</p></div>`;
 
   const groupsSection = groups.length
     ? `<div class="region-info-section"><h4>Groups</h4><p class="region-info-groups">${groups.join(
@@ -653,6 +661,7 @@ function showRegionInfoPanel(regionId, hemisphere, regionInfo) {
     <h3>${name}</h3>
     <p class="region-info-subtitle">${hemisphere} Hemisphere • ID ${regionId}</p>
     ${descriptionSection}
+    ${embryonicOriginSection}
     <div class="region-info-section">
       <h4>Alternative Names</h4>
       ${renderInfoList(alternativeNames, "No alternative names recorded.")}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -55,6 +55,11 @@ canvas {
         letter-spacing: 0.03em;
 }
 
+#region-info-panel .region-info-embryonic-origin {
+        margin: 0.35rem 0 0;
+        line-height: 1.4;
+}
+
 #region-info-panel .region-info-list {
         margin: 0.35rem 0 0;
         padding-left: 1.25rem;


### PR DESCRIPTION
## Summary
- add an embryonic origin section to the region info panel populated from the reference metadata
- style the embryonic origin text to align with existing panel spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db4bab9818833184d600369837289c