### PR TITLE
Add citation markers to brain region descriptions

### DIFF
--- a/public/reference.json
+++ b/public/reference.json
@@ -21,7 +21,10 @@
       "Receives axons from olfactory receptor neurons via the olfactory nerve.",
       "Projects to the piriform cortex, amygdala, and entorhinal cortex."
     ],
-    "embryonic_origin": "Telencephalon"
+    "embryonic_origin": "Telencephalon",
+    "citations": [
+      "https://portal.brain-map.org/explore/allen-brain-atlas"
+    ]
   },
   "2": {
     "name": "Anterior Olfactory Nucleus",
@@ -44,7 +47,10 @@
       "Maintains reciprocal connections with the olfactory bulb and piriform cortex.",
       "Links the two olfactory bulbs through anterior commissure fibers."
     ],
-    "embryonic_origin": "Undetermined"
+    "embryonic_origin": "Undetermined",
+    "citations": [
+      "https://www.ncbi.nlm.nih.gov/books/NBK551517/"
+    ]
   },
   "3": {
     "name": "Piriform Cortex",
@@ -69,7 +75,10 @@
       "Receives dense afferents from the olfactory bulb and anterior olfactory nucleus.",
       "Projects to orbitofrontal cortex, amygdala, entorhinal cortex, and hypothalamic olfactory areas."
     ],
-    "embryonic_origin": "Telencephalon"
+    "embryonic_origin": "Telencephalon",
+    "citations": [
+      "Gottfried JA. Central mechanisms of odour object perception. Nat Rev Neurosci. 2010;11(9):628-641."
+    ]
   },
   "4": {
     "name": "Anterior (Agranular) Insular Cortex",

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -45,6 +45,36 @@ canvas {
         line-height: 1.5;
 }
 
+#region-info-panel .region-info-citations {
+        display: inline-flex;
+        gap: 0.35rem;
+        margin-left: 0.5rem;
+        font-size: 0.85em;
+        color: var(--grey-primary);
+        vertical-align: middle;
+}
+
+#region-info-panel .region-info-citation {
+        display: inline-block;
+        color: inherit;
+        text-decoration: none;
+        font-weight: 600;
+}
+
+#region-info-panel .region-info-citation:hover,
+#region-info-panel .region-info-citation:focus-visible {
+        color: var(--white);
+        text-decoration: underline;
+}
+
+#region-info-panel a.region-info-citation {
+        cursor: pointer;
+}
+
+#region-info-panel span.region-info-citation {
+        cursor: help;
+}
+
 #region-info-panel .region-info-section + .region-info-section {
         margin-top: 0.75rem;
 }


### PR DESCRIPTION
## Summary
- render optional citation markers at the end of each region description
- style the new citation markers for consistency with the info panel
- seed example citation data for several regions in the reference dataset

## Testing
- `npm run build` *(fails: Rollup cannot resolve three-mesh-bvh)*

------
https://chatgpt.com/codex/tasks/task_e_68dc62cb84748331ab59244738eefe18