### PR TITLE
Refine region reference display

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -45,34 +45,45 @@ canvas {
         line-height: 1.5;
 }
 
-#region-info-panel .region-info-citations {
-        display: inline-flex;
-        gap: 0.35rem;
-        margin-left: 0.5rem;
-        font-size: 0.85em;
-        color: var(--grey-primary);
-        vertical-align: middle;
+#region-info-panel .region-info-section-citations {
+        margin-top: 0.75rem;
 }
 
-#region-info-panel .region-info-citation {
-        display: inline-block;
-        color: inherit;
-        text-decoration: none;
+#region-info-panel .region-info-citation-list {
+        margin: 0.35rem 0 0;
+        padding: 0;
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+}
+
+#region-info-panel .region-info-citation-item {
+        display: flex;
+        align-items: baseline;
+        gap: 0.5rem;
+        line-height: 1.4;
+}
+
+#region-info-panel .region-info-citation-label {
+        color: var(--grey-secondary);
         font-weight: 600;
+        flex-shrink: 0;
 }
 
-#region-info-panel .region-info-citation:hover,
-#region-info-panel .region-info-citation:focus-visible {
+#region-info-panel .region-info-citation-text,
+#region-info-panel .region-info-citation-link {
+        color: var(--grey-primary);
+}
+
+#region-info-panel .region-info-citation-link {
+        text-decoration: none;
+}
+
+#region-info-panel .region-info-citation-link:hover,
+#region-info-panel .region-info-citation-link:focus-visible {
         color: var(--white);
         text-decoration: underline;
-}
-
-#region-info-panel a.region-info-citation {
-        cursor: pointer;
-}
-
-#region-info-panel span.region-info-citation {
-        cursor: help;
 }
 
 #region-info-panel .region-info-section + .region-info-section {


### PR DESCRIPTION
## Summary
- remove inline citation markers from the region description to prevent automatic footnote suffixes
- add a dedicated references section that renders citations with legacy-inspired styling and accessibility labels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd334a63248331b637e2c3da6741da