### PR TITLE
Allow searching by brain region aliases

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -293,12 +293,22 @@
           const selectionElement = document.createElement("li");
           selectionElement.classList.add("selection-element");
           selectionElement.value = String(key);
+
+          const aliasTerms = Array.isArray(region.aliases)
+            ? region.aliases
+            : typeof region.aliases === "string"
+              ? [region.aliases]
+              : [];
+
           const searchTerms = [
             region.name,
+            ...aliasTerms,
             ...(region.keywords ?? []),
             ...(region.groups ?? []),
             region.description ?? "",
           ]
+            .map((term) => (typeof term === "string" ? term.trim() : ""))
+            .filter(Boolean)
             .join(" ")
             .toLowerCase();
           selectionElement.dataset.search = searchTerms;


### PR DESCRIPTION
## Summary
- include region aliases when constructing search keywords so alias queries surface results
- normalize search terms by trimming strings before storing the dataset values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd409bc2bc8331be4fe82369e40dbe