### PR TITLE
Add NeuroNav branding updates to navbar

### DIFF
--- a/public/neuronav-logo.svg
+++ b/public/neuronav-logo.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">NeuroNav Logo</title>
+  <desc id="desc">Stylized brain orbiting a navigation marker</desc>
+  <defs>
+    <linearGradient id="gradient" x1="12" y1="12" x2="52" y2="52" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7f9cf5" />
+      <stop offset="1" stop-color="#43c6ac" />
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="30" fill="#101322" />
+  <path
+    d="M32 12c-9.94 0-18 7.28-18 16.26 0 9.69 10.44 14.7 14.48 16.43L32 52l3.52-7.3C39.56 43 50 37.95 50 28.26 50 19.28 41.94 12 32 12Zm0 6.4c6.47 0 11.72 4.65 11.72 10.39 0 6.79-7.63 10.56-9.8 11.42l-1.92 0.77-1.92-0.77c-2.17-0.86-9.8-4.63-9.8-11.42 0-5.74 5.25-10.39 11.72-10.39Z"
+    fill="url(#gradient)"
+  />
+  <path
+    d="M32 21.5a6.5 6.5 0 0 0-6.5 6.5c0 5.67 6.5 8.3 6.5 8.3s6.5-2.63 6.5-8.3A6.5 6.5 0 0 0 32 21.5Zm0 3a3.5 3.5 0 0 1 3.5 3.5c0 2.18-2.17 3.81-3.5 4.4-1.33-0.59-3.5-2.22-3.5-4.4A3.5 3.5 0 0 1 32 24.5Z"
+    fill="#ffffff"
+    opacity="0.85"
+  />
+  <path
+    d="M16 32a1.5 1.5 0 0 1 0-3c6 0 8.54-2.51 10.53-4.47C28.41 22.68 30.07 21 33 21s4.59 1.68 6.47 3.53C41.46 26.49 44 29 50 29a1.5 1.5 0 0 1 0 3c-7.38 0-10.57-3.25-12.68-5.31C35.47 24.88 34.33 24 33 24s-2.47 0.88-4.32 2.69C26.57 28.75 23.38 32 16 32Z"
+    fill="#8ef6ff"
+    opacity="0.6"
+  />
+</svg>

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="styles/style.css" />
+    <link rel="icon" type="image/svg+xml" href="/neuronav-logo.svg" />
     <title>NeuroNav 🧠</title>
   </head>
   <body>
@@ -23,7 +24,14 @@
         </svg>
       </div>
       <div class="item nav-header">
-        <p id="title">NEURONAV</p>
+        <div id="title">
+          <img
+            src="/neuronav-logo.svg"
+            alt="NeuroNav logo"
+            class="navbar-logo"
+          />
+          <span>NeuroNav</span>
+        </div>
       </div>
       <div class="item nav-search">
         <div class="search-box">

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -179,20 +179,31 @@ canvas {
 }
 
 .nav-header {
-	grid-row: 1 / 3;
-	grid-column: 3 / 10;
-	justify-self: center;
-	align-self: center;
-	opacity: 0;
-	transition: opacity 200ms ease;
+        grid-row: 1 / 3;
+        grid-column: 3 / 10;
+        justify-self: center;
+        align-self: center;
+        opacity: 0;
+        transition: opacity 200ms ease;
 }
 
 #title {
-	color: var(--font-color);
-	font-size: var(--font-size-title);
-	font-weight: bold;
-	letter-spacing: var(--letter-spacing-secondary);
-	filter: drop-shadow(0 0 0.15rem lightblue);
+        display: inline-flex;
+        align-items: center;
+        gap: 0.75rem;
+        filter: drop-shadow(0 0 0.15rem lightblue);
+}
+
+#title span {
+        color: var(--font-color);
+        font-size: var(--font-size-title);
+        font-weight: bold;
+        letter-spacing: 0.35rem;
+}
+
+.navbar-logo {
+        width: 3.5rem;
+        height: 3.5rem;
 }
 
 .nav-atlas {


### PR DESCRIPTION
## Summary
- add a reusable NeuroNav SVG logo asset and reference it as the site favicon
- update the navigation header to display the new logo alongside the NeuroNav name
- adjust navbar styling to accommodate the mixed-case title and inline icon

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0749de6f88331a54bab5126666504