### PR TITLE
Adjust dropdown header alignment

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -385,15 +385,21 @@ canvas {
 }
 
 #hemisphere-text {
-	grid-row: 1 / 2;
-	grid-column: 4 / 5;
-	justify-self: center;
+        grid-row: 1 / 2;
+        grid-column: 4 / 5;
+        justify-self: stretch;
+        text-align: center;
+        margin-left: 0;
+        margin-right: 0;
 }
 
 #color-text {
-	grid-row: 1 / 2;
-	grid-column: 5 / 6;
-	justify-self: center;
+        grid-row: 1 / 2;
+        grid-column: 5 / 6;
+        justify-self: stretch;
+        text-align: center;
+        margin-left: 0;
+        margin-right: 0;
 }
 
 #toggle-text {
@@ -466,16 +472,17 @@ canvas {
 }
 
 .eye-container {
-	grid-column: 6 / 7;
-	justify-self: center;
-	align-self: center;
-	width: 20px;
-	height: 30px;
-	fill: white;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	justify-content: center;
+        grid-column: 6 / 7;
+        justify-self: center;
+        align-self: start;
+        margin-top: 2px;
+        width: 20px;
+        height: 30px;
+        fill: white;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
 }
 
 #eye-open-icon {


### PR DESCRIPTION
## Summary
- center the Hemisphere and Color banner labels over their respective dropdowns
- align the eye toggle icons with the Toggle View column for improved layout consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0bfb09d1c8331b737b79efeea7ac6