### PR TITLE
Make region info panel width adaptive

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -757,6 +757,51 @@ function processTooltipRaycast() {
 
 const infoPanel = document.getElementById("region-info-panel");
 
+const REGION_INFO_PANEL_WIDTH = {
+  minRem: 18,
+  maxRem: 32,
+  stepRem: 1,
+};
+
+function resetRegionInfoPanelWidth(panel) {
+  if (!panel) return;
+  panel.style.removeProperty("--region-info-panel-width");
+  panel.classList.remove("region-info-panel-scrollable");
+}
+
+function adjustRegionInfoPanelWidth(panel) {
+  if (!panel) return;
+
+  const { minRem, maxRem, stepRem } = REGION_INFO_PANEL_WIDTH;
+  const rootFontSize = Number.parseFloat(
+    getComputedStyle(document.documentElement).fontSize,
+  );
+
+  if (!Number.isFinite(rootFontSize) || rootFontSize <= 0) {
+    resetRegionInfoPanelWidth(panel);
+    return;
+  }
+
+  let widthRem = minRem;
+  panel.style.setProperty("--region-info-panel-width", `${widthRem}rem`);
+  panel.classList.remove("region-info-panel-scrollable");
+
+  // Trigger layout before measuring so the new width takes effect.
+  panel.getBoundingClientRect();
+
+  while (panel.scrollHeight > panel.clientHeight && widthRem < maxRem) {
+    widthRem = Math.min(widthRem + stepRem, maxRem);
+    panel.style.setProperty("--region-info-panel-width", `${widthRem}rem`);
+    panel.getBoundingClientRect();
+  }
+
+  if (panel.scrollHeight > panel.clientHeight) {
+    panel.classList.add("region-info-panel-scrollable");
+  } else {
+    panel.classList.remove("region-info-panel-scrollable");
+  }
+}
+
 function escapeHtml(value) {
   if (value == null) {
     return "";
@@ -903,6 +948,8 @@ function showRegionInfoPanel(regionId, hemisphere, regionInfo) {
 
   infoPanel.classList.add("visible");
   infoPanel.setAttribute("aria-hidden", "false");
+
+  adjustRegionInfoPanelWidth(infoPanel);
 }
 
 function hideRegionInfoPanel() {
@@ -911,6 +958,7 @@ function hideRegionInfoPanel() {
   infoPanel.classList.remove("visible");
   infoPanel.setAttribute("aria-hidden", "true");
   infoPanel.innerHTML = "";
+  resetRegionInfoPanelWidth(infoPanel);
 }
 
 if (infoPanel) {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -9,7 +9,8 @@ canvas {
         position: fixed;
         top: 1.5rem;
         left: 1.5rem;
-        max-width: 22rem;
+        width: var(--region-info-panel-width, var(--region-info-panel-min-width, 18rem));
+        max-width: var(--region-info-panel-max-width, 32rem);
         max-height: calc(100vh - 3rem);
         padding: 1rem 1.25rem;
         border-radius: var(--border-radius);
@@ -18,12 +19,16 @@ canvas {
         box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
         backdrop-filter: blur(6px);
         display: none;
-        overflow-y: auto;
+        overflow-y: hidden;
         z-index: 5;
 }
 
 #region-info-panel.visible {
         display: block;
+}
+
+#region-info-panel.region-info-panel-scrollable {
+        overflow-y: auto;
 }
 
 #region-info-panel h3 {
@@ -109,14 +114,17 @@ canvas {
 	--grey-secondary: #434b5b;
 	--grey-tertiary: #22252e;
 	--grey-quaternary: rgb(30, 30, 37, 1);
-	--grey-pentanary: #1a1920;
+        --grey-pentanary: #1a1920;
 
-	--black: #000;
-	--white: #fff;
+        --black: #000;
+        --white: #fff;
 
-	--border-radius: 5px;
+        --border-radius: 5px;
 
-	--icon-fill: #22252e;
+        --icon-fill: #22252e;
+
+        --region-info-panel-min-width: 18rem;
+        --region-info-panel-max-width: 32rem;
 }
 
 .navbar {


### PR DESCRIPTION
## Summary
- allow the region info panel to start at a compact width and expand until content no longer overflows
- adjust styling to expose configurable width variables and toggle overflow handling based on scrollability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e135e7ca388331a3275975bac03ca5