### PR TITLE
Add smooth splash screen transitions

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -136,7 +136,12 @@ canvas {
         background: var(--white);
         z-index: 20;
         opacity: 1;
-        transition: opacity 600ms ease;
+        transform: scale(1);
+        transition:
+                opacity 600ms ease,
+                transform 600ms ease;
+        animation: splash-fade-in 700ms ease forwards;
+        will-change: opacity, transform;
 }
 
 .splash-content {
@@ -161,13 +166,26 @@ canvas {
 
 .splash-hidden {
         opacity: 0;
-        visibility: hidden;
         pointer-events: none;
+        transform: scale(0.98);
+}
+
+@keyframes splash-fade-in {
+        from {
+                opacity: 0;
+                transform: scale(0.98);
+        }
+
+        to {
+                opacity: 1;
+                transform: scale(1);
+        }
 }
 
 @media (prefers-reduced-motion: reduce) {
         #splash-screen {
                 transition: none;
+                animation: none;
         }
 }
 


### PR DESCRIPTION
## Summary
- animate the splash screen on entry and exit to reduce abrupt changes
- respect prefers-reduced-motion by disabling the new effects when requested

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e147b8cc8483318cf806f869616892