### PR TITLE
Enhance splash screen fade-out animation

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -137,7 +137,8 @@ canvas {
         z-index: 20;
         opacity: 1;
         visibility: visible;
-        transition: opacity 420ms ease, visibility 0s linear 420ms;
+        transition: opacity 650ms cubic-bezier(0.22, 1, 0.36, 1),
+                visibility 0s linear 650ms;
         will-change: opacity;
 }
 
@@ -177,10 +178,9 @@ canvas {
         pointer-events: none;
 }
 
-#splash-screen.splash-hidden .splash-content {
-        opacity: 0;
-        transform: translateY(-12px);
-        animation: none;
+#splash-screen.splash-hiding .splash-content {
+        animation: splash-content-conceal 650ms cubic-bezier(0.22, 1, 0.36, 1)
+                forwards;
 }
 
 @keyframes splash-content-reveal {
@@ -192,6 +192,18 @@ canvas {
         to {
                 opacity: 1;
                 transform: translateY(0);
+        }
+}
+
+@keyframes splash-content-conceal {
+        from {
+                opacity: 1;
+                transform: translateY(0);
+        }
+
+        to {
+                opacity: 0;
+                transform: translateY(18px);
         }
 }
 


### PR DESCRIPTION
## Summary
- match the splash screen fade-out timing and easing with the fade-in animation for consistency
- animate the splash content while hiding to mirror the reveal motion

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1608293008331a5537a3827554e1b