### PR TITLE
Add dynamic search suggestions to search bar

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -47,6 +47,7 @@
           </svg>
           <input type="text" id="search-bar" />
         </div>
+        <p class="search-suggestion" aria-live="polite"></p>
       </div>
       <div class="item nav-showall-btn">
         <button onclick="showSelected()" id="showall-btn">Show Selected</button>
@@ -364,6 +365,7 @@
 
         const selectionList = document.querySelector(".selection-list");
         let defaultColorIndex = 0;
+        const keywordAccumulator = new Map();
 
         for (const key in regions) {
           const region = regions[key];
@@ -377,10 +379,26 @@
               ? [region.aliases]
               : [];
 
+          const regionKeywords = Array.isArray(region.keywords)
+            ? region.keywords
+            : typeof region.keywords === "string"
+              ? [region.keywords]
+              : [];
+
+          regionKeywords
+            .map((keyword) => (typeof keyword === "string" ? keyword.trim() : ""))
+            .filter(Boolean)
+            .forEach((keyword) => {
+              const keyName = keyword.toLowerCase();
+              if (!keywordAccumulator.has(keyName)) {
+                keywordAccumulator.set(keyName, keyword);
+              }
+            });
+
           const searchTerms = [
             region.name,
             ...aliasTerms,
-            ...(region.keywords ?? []),
+            ...regionKeywords,
             ...(region.groups ?? []),
             region.description ?? "",
           ]
@@ -471,6 +489,11 @@
 
           defaultColorIndex = (defaultColorIndex + 1) % colorOptions.length;
         }
+
+        const initializeSuggestions = window.initializeSearchSuggestions;
+        if (typeof initializeSuggestions === "function") {
+          initializeSuggestions(Array.from(keywordAccumulator.values()));
+        }
       }
     </script>
     <script type="module">
@@ -498,6 +521,77 @@
       }
 
       const searchBar = document.querySelector("#search-bar");
+      const searchSuggestion = document.querySelector(".search-suggestion");
+      let keywordSuggestions = [];
+      let suggestionIndex = 0;
+      let suggestionTimeoutId;
+      let suggestionFadeTimeoutId;
+      const SUGGESTION_DISPLAY_DURATION = 5000;
+      const SUGGESTION_FADE_DURATION = 600;
+
+      function stopSuggestionCycle() {
+        clearTimeout(suggestionTimeoutId);
+        clearTimeout(suggestionFadeTimeoutId);
+        if (searchSuggestion) {
+          searchSuggestion.classList.remove("visible");
+        }
+      }
+
+      function showNextSuggestion() {
+        if (!searchSuggestion || keywordSuggestions.length === 0) {
+          return;
+        }
+
+        const nextSuggestion = keywordSuggestions[suggestionIndex];
+        suggestionIndex = (suggestionIndex + 1) % keywordSuggestions.length;
+
+        searchSuggestion.textContent = `Try searching "${nextSuggestion}"…`;
+        requestAnimationFrame(() => {
+          searchSuggestion.classList.add("visible");
+        });
+
+        suggestionTimeoutId = setTimeout(() => {
+          searchSuggestion.classList.remove("visible");
+          suggestionFadeTimeoutId = setTimeout(
+            showNextSuggestion,
+            SUGGESTION_FADE_DURATION,
+          );
+        }, SUGGESTION_DISPLAY_DURATION);
+      }
+
+      function startSuggestionCycle() {
+        stopSuggestionCycle();
+        if (!searchSuggestion || keywordSuggestions.length === 0) {
+          return;
+        }
+        if (searchBar.value.trim() !== "") {
+          return;
+        }
+        showNextSuggestion();
+      }
+
+      function initializeSearchSuggestions(suggestions = []) {
+        keywordSuggestions = suggestions;
+        suggestionIndex = 0;
+        if (keywordSuggestions.length === 0) {
+          stopSuggestionCycle();
+          return;
+        }
+        startSuggestionCycle();
+      }
+
+      window.initializeSearchSuggestions = initializeSearchSuggestions;
+
+      function handleSearchInput() {
+        filterItemsBySearch();
+        if (searchBar.value.trim() === "") {
+          startSuggestionCycle();
+        } else {
+          stopSuggestionCycle();
+        }
+      }
+
+      searchBar.addEventListener("input", handleSearchInput);
       searchBar.addEventListener("keyup", filterItemsBySearch);
 
       // SHOW CURRENT REGIONS //

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -334,24 +334,39 @@ canvas {
 }
 
 .nav-search {
-	align-self: center;
-	grid-row: 3 / 4;
-	grid-column: 1 / 9;
-	display: flex;
-	justify-content: space-between;
-	align-content: center;
-	transition: opacity 200ms ease;
-	opacity: 0;
+        align-self: center;
+        grid-row: 3 / 4;
+        grid-column: 1 / 9;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: flex-start;
+        gap: 0.35rem;
+        transition: opacity 200ms ease;
+        opacity: 0;
 }
 
 .search-box {
-	width: 29rem;
-	height: 2.5rem;
-	background: #313743;
-	border-radius: var(--border-radius);
-	display: flex;
-	align-items: center;
-	margin: 10px;
+        width: 29rem;
+        height: 2.5rem;
+        background: #313743;
+        border-radius: var(--border-radius);
+        display: flex;
+        align-items: center;
+        margin: 10px;
+}
+
+.search-suggestion {
+        margin-left: 12px;
+        font-size: 0.85rem;
+        color: rgba(255, 255, 255, 0.75);
+        transition: opacity 600ms ease-in-out;
+        opacity: 0;
+        pointer-events: none;
+}
+
+.search-suggestion.visible {
+        opacity: 1;
 }
 
 #search-icon {


### PR DESCRIPTION
## Summary
- add a rotating "Try searching…" hint below the search bar that pulls keywords from reference.json
- update keyword parsing to deduplicate keyword strings and share them with the suggestion cycle
- tweak the sidebar search layout and styles so the animated suggestions can fade in and out cleanly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1d2911fa08331828e537e6fb8579f