### PR TITLE
Add rotating keyword suggestions to search bar

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -47,6 +47,7 @@
           </svg>
           <input type="text" id="search-bar" />
         </div>
+        <p id="search-suggestion" class="search-suggestion" aria-live="polite"></p>
       </div>
       <div class="item nav-showall-btn">
         <button onclick="showSelected()" id="showall-btn">Show Selected</button>
@@ -347,6 +348,7 @@
         .then((response) => response.json())
         .then((regions) => {
           handleRegions(regions);
+          startSearchSuggestions(regions);
         })
         .catch((error) => {});
 
@@ -471,6 +473,62 @@
 
           defaultColorIndex = (defaultColorIndex + 1) % colorOptions.length;
         }
+      }
+
+      function startSearchSuggestions(regions) {
+        const suggestionElement = document.querySelector("#search-suggestion");
+        if (!suggestionElement) {
+          return;
+        }
+
+        const keywordSet = new Set();
+        Object.values(regions).forEach((region) => {
+          (region?.keywords ?? []).forEach((keyword) => {
+            if (typeof keyword === "string") {
+              const trimmed = keyword.trim();
+              if (trimmed) {
+                keywordSet.add(trimmed);
+              }
+            }
+          });
+        });
+
+        if (!keywordSet.size) {
+          return;
+        }
+
+        const suggestions = shuffleArray(Array.from(keywordSet)).map(
+          (keyword) => `Try searching "${keyword}"...`,
+        );
+
+        suggestionElement.textContent = suggestions[0];
+        suggestionElement.classList.add("visible");
+
+        if (suggestions.length === 1) {
+          return;
+        }
+
+        let suggestionIndex = 1;
+        const fadeDuration = 600;
+        const displayDuration = 4400;
+
+        setInterval(() => {
+          suggestionElement.classList.remove("visible");
+          setTimeout(() => {
+            suggestionElement.textContent = suggestions[suggestionIndex];
+            suggestionElement.classList.add("visible");
+            suggestionIndex = (suggestionIndex + 1) % suggestions.length;
+          }, fadeDuration);
+        }, displayDuration);
+      }
+
+      function shuffleArray(array) {
+        const arr = [...array];
+        for (let i = arr.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [arr[i], arr[j]] = [arr[j], arr[i]];
+        }
+        return arr;
       }
     </script>
     <script type="module">

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -334,14 +334,15 @@ canvas {
 }
 
 .nav-search {
-	align-self: center;
-	grid-row: 3 / 4;
-	grid-column: 1 / 9;
-	display: flex;
-	justify-content: space-between;
-	align-content: center;
-	transition: opacity 200ms ease;
-	opacity: 0;
+        align-self: center;
+        grid-row: 3 / 4;
+        grid-column: 1 / 9;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: flex-start;
+        transition: opacity 200ms ease;
+        opacity: 0;
 }
 
 .search-box {
@@ -371,8 +372,22 @@ canvas {
 	outline: none;
 	font-size: 18px;
 	margin-left: 35px;
-	color: var(--white);
-	background-color: #313743;
+        color: var(--white);
+        background-color: #313743;
+}
+
+.search-suggestion {
+        margin: 0 10px 10px;
+        font-size: 0.9rem;
+        color: rgba(255, 255, 255, 0.75);
+        opacity: 0;
+        transition: opacity 600ms ease;
+        min-height: 1.2rem;
+        pointer-events: none;
+}
+
+.search-suggestion.visible {
+        opacity: 1;
 }
 
 .nav-showall-btn {


### PR DESCRIPTION
## Summary
- add a live suggestion element next to the search field that cycles through reference keywords
- gather keywords from `reference.json`, shuffle them, and fade suggestions in and out for guidance
- adjust navigation search layout and styling to accommodate the animated helper text

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1d2911fa08331828e537e6fb8579f