### PR TITLE
Align nav search with selection list

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -335,13 +335,14 @@ canvas {
 
 
 .nav-search {
-        align-self: center;
         grid-row: 3 / 4;
-        grid-column: 1 / 11;
+        grid-column: 1 / -1;
         display: flex;
         align-items: center;
         gap: 0.75rem;
-        padding: 0;
+        padding: 0.7rem 10px;
+        box-sizing: border-box;
+        justify-self: stretch;
         transition: opacity 200ms ease;
         opacity: 0;
 }


### PR DESCRIPTION
## Summary
- stretch the nav search grid cell to match the full sidebar width
- add consistent horizontal padding so the search controls align with the selection list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e1fdfbec8331aa0b6620382ce551