### PR TITLE
Fix search bar border radius styles

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -403,6 +403,7 @@ canvas {
         position: relative;
         z-index: 1;
         border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
 }
 
 .nav-search-action {
@@ -414,10 +415,10 @@ canvas {
         background-color: #313743;
         color: var(--white);
         border: none;
-        border-radius-top-left: var(--border-radius);
-        border-radius-bottom-left: var(--border-radius);
-        border-radius-top-right: 0;
-        border-radius-bottom-right: 0;
+        border-top-left-radius: var(--border-radius);
+        border-bottom-left-radius: var(--border-radius);
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
         font-weight: bold;
         white-space: nowrap;
         flex-shrink: 0;
@@ -446,7 +447,7 @@ canvas {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
         border-top-right-radius: var(--border-radius);
-        border-top-left-radius: var(--border-radius);
+        border-bottom-right-radius: var(--border-radius);
 }
 
 .nav-outliner {


### PR DESCRIPTION
## Summary
- use valid CSS border radius properties on the search action buttons
- remove the right-edge rounding on the search input so it aligns with the buttons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e7429ed0833185b1217cdf5d1e6e