### PR TITLE
Clear search input when leaving the site

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -606,6 +606,27 @@
       searchBar.addEventListener("input", handleSearchInput);
       searchBar.addEventListener("keyup", filterItemsBySearch);
 
+      function resetSearchBar() {
+        if (!searchBar) {
+          return;
+        }
+
+        if (searchBar.value === "") {
+          return;
+        }
+
+        searchBar.value = "";
+        handleSearchInput();
+      }
+
+      window.addEventListener("pagehide", resetSearchBar);
+      window.addEventListener("beforeunload", resetSearchBar);
+      window.addEventListener("pageshow", (event) => {
+        if (event.persisted) {
+          resetSearchBar();
+        }
+      });
+
       // SHOW CURRENT REGIONS //
 
       function showSelected() {


### PR DESCRIPTION
## Summary
- add a reusable reset helper that clears the search bar when users navigate away
- hook the reset into pagehide, beforeunload, and pageshow to cover BFCache restores

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2f0c235c88331b6699512c9373268