### PR TITLE
Pan camera when opening sidebar

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -316,6 +316,9 @@
         "description-boxes-checkbox",
       );
 
+      const NAVBAR_EXPANDED_WIDTH_REM = 35.5;
+      const NAVBAR_COLLAPSED_WIDTH_REM = 6;
+
       let darkMode = false;
       let navOpen = false;
 
@@ -329,7 +332,9 @@
       function toggleSidebar() {
         const isOpen = !navOpen;
         navOpen = isOpen;
-        const sidebarWidth = isOpen ? "35.5rem" : "6rem";
+        const sidebarWidth = `${
+          isOpen ? NAVBAR_EXPANDED_WIDTH_REM : NAVBAR_COLLAPSED_WIDTH_REM
+        }rem`;
         const sidebarOpacity = isOpen ? 1 : 0;
         const backgroundColor = isOpen
           ? "rgb(30, 30, 37, 1)"
@@ -346,6 +351,16 @@
         showAllButton.style.opacity = sidebarOpacity;
         outliner.style.opacity = sidebarOpacity;
         settings.style.opacity = sidebarOpacity;
+
+        window.dispatchEvent(
+          new CustomEvent("neuronav:sidebar-toggle", {
+            detail: {
+              open: isOpen,
+              expandedWidthRem: NAVBAR_EXPANDED_WIDTH_REM,
+              collapsedWidthRem: NAVBAR_COLLAPSED_WIDTH_REM,
+            },
+          }),
+        );
       }
 
       function updateArrowFill() {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -172,7 +172,7 @@ function panCameraForSidebar(additionalWidthRem = sidebarAdditionalWidthRem) {
   if (desiredPanDistance > 0) {
     camera.getWorldDirection(cameraForwardScratch);
     cameraRightScratch
-      .crossVectors(camera.up, cameraForwardScratch)
+      .crossVectors(cameraForwardScratch, camera.up)
       .normalize()
       .multiplyScalar(desiredPanDistance);
     targetOffset = cameraRightScratch;


### PR DESCRIPTION
## Summary
- add a sidebar toggle event that communicates the expanded navigation width
- compute a camera-right pan offset based on the sidebar width and animate the camera accordingly
- keep the pan distance in sync when the viewport is resized

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3053597cc8331a4aab5f70398abd9