### PR TITLE
Pan camera when opening navigation sidebar

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -346,6 +346,7 @@
         showAllButton.style.opacity = sidebarOpacity;
         outliner.style.opacity = sidebarOpacity;
         settings.style.opacity = sidebarOpacity;
+        setNavigationSidebarOpen(isOpen);
       }
 
       function updateArrowFill() {
@@ -357,9 +358,14 @@
       }
 
       setInitialState();
+      setNavigationSidebarOpen(navOpen);
     </script>
     <script type="module">
-      import { updateHemisphere, updateColor } from "/scripts/main.js";
+      import {
+        updateHemisphere,
+        updateColor,
+        setNavigationSidebarOpen,
+      } from "/scripts/main.js";
 
       // POPULATE OUTLINER ELEMENTS //
 


### PR DESCRIPTION
## Summary
- pan the camera to the right whenever the navigation sidebar opens so the brain shifts left in view
- keep camera animations and focus positions aligned with the sidebar offset while the menu is open
- expose a helper from the Three.js scene and call it from the UI toggle script to synchronize the states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3053597cc8331a4aab5f70398abd9