### PR TITLE
Prevent sidebar pan when near center or focusing region

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -60,7 +60,7 @@ let cameraAnimationState = null;
 let focusedRegionName = null;
 let sidebarAdditionalWidthRem = 0;
 const SIDEBAR_PAN_DURATION = 1000;
-const SIDEBAR_PAN_CENTER_RADIUS = 1.5; // Distance from origin below which sidebar pan is suppressed
+const SIDEBAR_PAN_CENTER_RADIUS = 3; // Distance from origin below which sidebar pan is suppressed
 const sidebarPanOffset = new THREE.Vector3();
 let sidebarBaseCameraPosition = null;
 let sidebarBaseTarget = null;
@@ -216,11 +216,16 @@ function panCameraForSidebar(
     sidebarIsOpen = explicitlyOpen;
 
     if (!sidebarIsOpen) {
+      const shouldSuppressPan =
+        isCameraNearSceneCenter() || hasFocusedRegion();
+      const hadSidebarOffset = sidebarPanOffset.lengthSq() > 1e-8;
+      const hasBaseTargets = sidebarBaseCameraPosition && sidebarBaseTarget;
+
+      sidebarPanSuppressed = shouldSuppressPan;
       sidebarAdditionalWidthRem = 0;
       sidebarPanOffset.set(0, 0, 0);
-      sidebarPanSuppressed = false;
 
-      if (sidebarBaseCameraPosition && sidebarBaseTarget) {
+      if (!shouldSuppressPan && hadSidebarOffset && hasBaseTargets) {
         animateCameraTo(sidebarBaseCameraPosition, sidebarBaseTarget, {
           duration: SIDEBAR_PAN_DURATION,
           easing: easeInOutSine,


### PR DESCRIPTION
## Summary
- suppress sidebar camera pan when the camera is near the scene origin or a brain region is focused
- track and clear the focused region state when panels or regions are dismissed so sidebar pan suppression is accurate

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e316dadd348331a14716309f8cbb41