### PR TITLE
Fix root mesh occlusion for region rendering

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -830,10 +830,16 @@ const _addRoot = async () => {
   // Define transparent root material
   const material = new THREE.MeshBasicMaterial({
     color: 0xd3d3d3,
-    // Setting depthWrite to false disables occlusion of brain regions by the root mesh
-    depthWrite: false,
     transparent: true,
     opacity: 0.15,
+    depthWrite: true,
+    depthTest: true,
+    polygonOffset: true,
+    // A slight negative factor nudges the root mesh toward the camera so that it
+    // consistently renders in front of bordering regions without altering the
+    // actual model transforms.
+    polygonOffsetFactor: -1,
+    polygonOffsetUnits: -1,
   });
 
   // Load the GLB file


### PR DESCRIPTION
## Summary
- ensure the root mesh writes to the depth buffer and applies a slight polygon offset so brain regions no longer overlap its surface

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e31ddebec0833186ea268bdfd5d3a5