### PR TITLE
Update navbar width variables and center control hints

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -302,6 +302,11 @@
       let darkMode = false;
       let navOpen = false;
 
+      document.documentElement.style.setProperty(
+        "--navbar-width",
+        `${NAVBAR_COLLAPSED_WIDTH_REM}rem`,
+      );
+
       Object.defineProperty(window, "__neuronavDarkMode__", {
         configurable: true,
         get() {
@@ -327,6 +332,10 @@
         const arrowRotation = isOpen ? "rotate(-180deg)" : "rotate(0deg)";
 
         navbar.style.width = sidebarWidth;
+        document.documentElement.style.setProperty(
+          "--navbar-width",
+          sidebarWidth,
+        );
         navbar.style.backgroundColor = backgroundColor;
         navArrow.style.transform = arrowRotation;
         updateArrowFill();

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -97,10 +97,10 @@ canvas {
 }
 
 :root {
-	font-size: var(--font-size);
-	font-family: var(--font-family);
-	letter-spacing: var(--letter-spacing-primary);
-	font-weight: var(--font-weight);
+        font-size: var(--font-size);
+        font-family: var(--font-family);
+        letter-spacing: var(--letter-spacing-primary);
+        font-weight: var(--font-weight);
 
 	--font-size: 14px;
 	--font-size-title: 50px;
@@ -127,6 +127,9 @@ canvas {
 
         --region-info-panel-min-width: 24rem;
         --region-info-panel-max-width: 32rem;
+
+        --navbar-collapsed-width: 6rem;
+        --navbar-expanded-width: 35.5rem;
 }
 
 #splash-screen {
@@ -230,11 +233,11 @@ canvas {
 }
 
 .navbar {
-	width: 6rem;
-	height: 100vh;
-	position: fixed;
-	top: 0;
-	right: 0;
+        width: var(--navbar-width, var(--navbar-collapsed-width));
+        height: 100vh;
+        position: fixed;
+        top: 0;
+        right: 0;
 	display: grid;
 	grid-template-rows: repeat(16, 50px);
 	grid-template-columns: repeat(11, 50px);
@@ -842,7 +845,9 @@ input:checked + .checkbox-button:before {
 .control-hints {
         position: fixed;
         bottom: 1rem;
-        left: 50%;
+        left: calc(
+                (100vw - var(--navbar-width, var(--navbar-collapsed-width))) / 2
+        );
         transform: translateX(-50%);
         display: inline-flex;
         align-items: center;
@@ -854,6 +859,9 @@ input:checked + .checkbox-button:before {
         pointer-events: none;
         z-index: 4;
         text-align: center;
+        max-width: calc(
+                100vw - var(--navbar-width, var(--navbar-collapsed-width)) - 2rem
+        );
 }
 
 .control-hints strong {


### PR DESCRIPTION
## Summary
- add CSS custom properties for the sidebar widths and consume a dynamic navbar width
- keep the control hints banner centered within the available viewport space
- synchronize the navbar width custom property with sidebar toggling in the UI script

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e33903b6188331af285b4dad372788