### PR TITLE
Adjust control hints positioning

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -336,6 +336,10 @@
           "--navbar-width",
           sidebarWidth,
         );
+        document.documentElement.style.setProperty(
+          "--control-hints-offset",
+          isOpen ? `${NAVBAR_EXPANDED_WIDTH_REM}rem` : "0rem",
+        );
         navbar.style.backgroundColor = backgroundColor;
         navArrow.style.transform = arrowRotation;
         updateArrowFill();

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -130,6 +130,7 @@ canvas {
 
         --navbar-collapsed-width: 6rem;
         --navbar-expanded-width: 35.5rem;
+        --control-hints-offset: 0rem;
 }
 
 #splash-screen {
@@ -845,9 +846,7 @@ input:checked + .checkbox-button:before {
 .control-hints {
         position: fixed;
         bottom: 1rem;
-        left: calc(
-                (100vw - var(--navbar-width, var(--navbar-collapsed-width))) / 2
-        );
+        left: calc(50vw - (var(--control-hints-offset, 0rem) / 2));
         transform: translateX(-50%);
         display: inline-flex;
         align-items: center;


### PR DESCRIPTION
## Summary
- add a CSS variable to control the control-hints horizontal offset
- update the sidebar toggle logic to keep the control hints aligned as the navbar animates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e33f11baa8833188df01cd04bb6001