### PR TITLE
Align control hints fade with sidebar animation

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -320,6 +320,9 @@
 
       window.__neuronavDarkMode__ = darkMode;
       updateControlHintsColor(darkMode);
+      if (controlHints) {
+        controlHints.style.opacity = 1;
+      }
 
       function toggleSidebar() {
         const isOpen = !navOpen;
@@ -351,6 +354,9 @@
         showAllButton.style.opacity = sidebarOpacity;
         outliner.style.opacity = sidebarOpacity;
         settings.style.opacity = sidebarOpacity;
+        if (controlHints) {
+          controlHints.style.opacity = isOpen ? 0 : 1;
+        }
 
         window.dispatchEvent(
           new CustomEvent("neuronav:sidebar-toggle", {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -861,9 +861,11 @@ input:checked + .checkbox-button:before {
         max-width: calc(
                 100vw - var(--navbar-width, var(--navbar-collapsed-width)) - 2rem
         );
+        opacity: 1;
         transition:
                 left 1000ms ease,
-                max-width 1000ms ease;
+                max-width 1000ms ease,
+                opacity 1000ms ease;
 }
 
 .control-hints strong {


### PR DESCRIPTION
## Summary
- add an opacity transition to the control hints banner so it fades with the navbar width animation
- toggle the control hints opacity alongside the sidebar state and ensure it remains visible on load

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e34618c6f48331a98bfe3d8c00e27b