### PR TITLE
Refine utility icons layout and styling

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -135,6 +135,19 @@
         </div>
       </div>
     </nav>
+    <div
+      id="camera-icon-container"
+      tabindex="0"
+      role="button"
+      aria-label="Capture screenshot"
+    >
+      <span class="camera-icon camera-icon--light" aria-hidden="true">
+        <img src="/camera-black.svg" alt="" />
+      </span>
+      <span class="camera-icon camera-icon--dark" aria-hidden="true">
+        <img src="/camera-white.svg" alt="" />
+      </span>
+    </div>
     <div id="info-icon-container" tabindex="0" aria-describedby="info-tooltip">
       <svg
         id="info-icon"
@@ -216,6 +229,7 @@
 
       const infoTooltip = document.getElementById("info-tooltip");
       const infoIconContainer = document.getElementById("info-icon-container");
+      const cameraIconContainer = document.getElementById("camera-icon-container");
       infoTooltip.innerHTML = `
         <p>Models adapted from the Allen Human Reference Atlas – 3D (2020), Version 1.0.0.</p>
         <p><strong>Dataset citation:</strong></p>
@@ -303,6 +317,12 @@
       let darkMode = false;
       let navOpen = false;
 
+      function updateCameraIconTheme(isDarkMode) {
+        if (cameraIconContainer) {
+          cameraIconContainer.dataset.darkMode = isDarkMode ? "true" : "false";
+        }
+      }
+
       document.documentElement.style.setProperty(
         "--navbar-width",
         `${NAVBAR_COLLAPSED_WIDTH_REM}rem`,
@@ -320,6 +340,7 @@
 
       window.__neuronavDarkMode__ = darkMode;
       updateControlHintsColor(darkMode);
+      updateCameraIconTheme(darkMode);
       if (controlHints) {
         controlHints.style.opacity = 1;
       }
@@ -894,9 +915,11 @@
           const updatedDarkMode = updateBackground();
           setDarkModeState(updatedDarkMode);
           updateControlHintsColor(updatedDarkMode);
+          updateCameraIconTheme(updatedDarkMode);
         } else {
           setDarkModeState(shouldUseDarkBackground);
           updateControlHintsColor(shouldUseDarkBackground);
+          updateCameraIconTheme(shouldUseDarkBackground);
         }
 
         updateArrowFill();

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -771,6 +771,80 @@ input:checked + .checkbox-button:before {
 	display: flex;
 }
 
+#camera-icon-container {
+        position: fixed;
+        right: var(--navbar-width, var(--navbar-collapsed-width));
+        bottom: 1.5rem;
+
+        width: 2.75rem;
+        height: 2.75rem;
+
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.9);
+        box-shadow: 0 10px 22px rgba(0, 0, 0, 0.22);
+
+        cursor: pointer;
+        transition:
+                right 1000ms ease,
+                box-shadow 200ms ease,
+                transform 200ms ease;
+        outline: none;
+
+        z-index: 4;
+}
+
+#camera-icon-container:hover {
+        box-shadow: 0 14px 26px rgba(0, 0, 0, 0.24);
+        transform: translateY(-2px);
+}
+
+#camera-icon-container:focus-visible {
+        outline: 2px solid var(--grey-tertiary);
+        outline-offset: 4px;
+}
+
+#camera-icon-container[data-dark-mode="true"] {
+        background: rgba(34, 37, 46, 0.92);
+        box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+#camera-icon-container[data-dark-mode="true"]:focus-visible {
+        outline-color: rgba(255, 255, 255, 0.9);
+}
+
+#camera-icon-container .camera-icon {
+        position: absolute;
+        inset: 0;
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        transition: opacity 180ms ease;
+}
+
+#camera-icon-container .camera-icon img {
+        width: 1.5rem;
+        height: 1.5rem;
+        display: block;
+}
+
+#camera-icon-container .camera-icon--dark {
+        opacity: 0;
+}
+
+#camera-icon-container[data-dark-mode="true"] .camera-icon--light {
+        opacity: 0;
+}
+
+#camera-icon-container[data-dark-mode="true"] .camera-icon--dark {
+        opacity: 1;
+}
+
 #info-icon-container {
         position: absolute;
         bottom: 2%;


### PR DESCRIPTION
## Summary
- position the camera control flush with the navbar using a dedicated container while restoring the info icon to its original placement
- keep the camera icon's dual-theme cross-fade wired into the dark mode toggle with the updated helper
- restyle the camera container and revert the info tooltip alignment to match the restored layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3ca7826ac8331a44fd8ffffc65dc6