### PR TITLE
Realign camera icon with sidebar and restore info tooltip

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -135,6 +135,25 @@
         </div>
       </div>
     </nav>
+    <div
+      id="camera-icon"
+      tabindex="0"
+      role="button"
+      aria-label="Capture screenshot"
+    >
+      <img
+        src="/camera-black.svg"
+        alt=""
+        class="camera-icon-image camera-icon-image--light"
+        aria-hidden="true"
+      />
+      <img
+        src="/camera-white.svg"
+        alt=""
+        class="camera-icon-image camera-icon-image--dark"
+        aria-hidden="true"
+      />
+    </div>
     <div id="info-icon-container" tabindex="0" aria-describedby="info-tooltip">
       <svg
         id="info-icon"
@@ -216,6 +235,7 @@
 
       const infoTooltip = document.getElementById("info-tooltip");
       const infoIconContainer = document.getElementById("info-icon-container");
+      const cameraIcon = document.getElementById("camera-icon");
       infoTooltip.innerHTML = `
         <p>Models adapted from the Allen Human Reference Atlas – 3D (2020), Version 1.0.0.</p>
         <p><strong>Dataset citation:</strong></p>
@@ -303,6 +323,17 @@
       let darkMode = false;
       let navOpen = false;
 
+      function updateCameraIconTheme(isDarkMode) {
+        const dataValue = isDarkMode ? "true" : "false";
+        if (cameraIcon) {
+          cameraIcon.dataset.darkMode = dataValue;
+        }
+      }
+
+      if (cameraIcon) {
+        cameraIcon.dataset.sidebarOpen = navOpen ? "true" : "false";
+      }
+
       document.documentElement.style.setProperty(
         "--navbar-width",
         `${NAVBAR_COLLAPSED_WIDTH_REM}rem`,
@@ -320,6 +351,7 @@
 
       window.__neuronavDarkMode__ = darkMode;
       updateControlHintsColor(darkMode);
+      updateCameraIconTheme(darkMode);
       if (controlHints) {
         controlHints.style.opacity = 1;
       }
@@ -348,6 +380,9 @@
         navbar.style.backgroundColor = backgroundColor;
         navArrow.style.transform = arrowRotation;
         updateArrowFill();
+        if (cameraIcon) {
+          cameraIcon.dataset.sidebarOpen = isOpen ? "true" : "false";
+        }
         header.style.opacity = sidebarOpacity;
         search.style.opacity = sidebarOpacity;
         clearBtn.style.opacity = sidebarOpacity;
@@ -894,9 +929,11 @@
           const updatedDarkMode = updateBackground();
           setDarkModeState(updatedDarkMode);
           updateControlHintsColor(updatedDarkMode);
+          updateCameraIconTheme(updatedDarkMode);
         } else {
           setDarkModeState(shouldUseDarkBackground);
           updateControlHintsColor(shouldUseDarkBackground);
+          updateCameraIconTheme(shouldUseDarkBackground);
         }
 
         updateArrowFill();

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -771,6 +771,67 @@ input:checked + .checkbox-button:before {
 	display: flex;
 }
 
+#camera-icon {
+        position: fixed;
+        bottom: 2%;
+        left: var(--navbar-width, var(--navbar-collapsed-width));
+
+        display: grid;
+        place-items: center;
+
+        width: 2.75rem;
+        height: 2.75rem;
+
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.9);
+        box-shadow: 0 10px 22px rgba(0, 0, 0, 0.22);
+
+        cursor: pointer;
+        transition: left 1000ms ease, box-shadow 200ms ease, transform 200ms ease;
+        outline: none;
+        z-index: 4;
+}
+
+#camera-icon:hover {
+        box-shadow: 0 14px 26px rgba(0, 0, 0, 0.24);
+        transform: translateY(-2px);
+}
+
+#camera-icon:focus-visible {
+        outline: 2px solid var(--grey-tertiary);
+        outline-offset: 4px;
+}
+
+#camera-icon[data-dark-mode="true"] {
+        background: rgba(34, 37, 46, 0.92);
+        box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+#camera-icon[data-dark-mode="true"]:focus-visible {
+        outline-color: rgba(255, 255, 255, 0.9);
+}
+
+#camera-icon img {
+        grid-area: 1 / 1 / 2 / 2;
+        width: 1.5rem;
+        height: 1.5rem;
+
+        display: block;
+        transition: opacity 180ms ease;
+}
+
+#camera-icon .camera-icon-image--dark {
+        opacity: 0;
+}
+
+#camera-icon[data-dark-mode="true"] .camera-icon-image--light {
+        opacity: 0;
+}
+
+#camera-icon[data-dark-mode="true"] .camera-icon-image--dark {
+        opacity: 1;
+}
+
 #info-icon-container {
         position: absolute;
         bottom: 2%;


### PR DESCRIPTION
## Summary
- reposition the camera icon alongside the navigation bar so it stays flush with the sidebar edge and animates with width changes
- restore the info icon to its original bottom-left placement and revert the tooltip styling to match the previous layout
- update the dark mode helper logic to target the new camera container so the light/dark SVGs cross-fade correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3ca7826ac8331a44fd8ffffc65dc6