### PR TITLE
Add camera utility icon with adaptive contrast

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -135,19 +135,29 @@
         </div>
       </div>
     </nav>
-    <div id="info-icon-container" tabindex="0" aria-describedby="info-tooltip">
-      <svg
-        id="info-icon"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 30 30"
-        width="480px"
-        height="480px"
-      >
-        <path
-          d="M15,3C8.373,3,3,8.373,3,15c0,6.627,5.373,12,12,12s12-5.373,12-12C27,8.373,21.627,3,15,3z M16,21h-2v-7h2V21z M15,11.5 c-0.828,0-1.5-0.672-1.5-1.5s0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5S15.828,11.5,15,11.5z"
+    <div id="utility-icon-bar">
+      <div id="info-icon-container" class="utility-icon-container" tabindex="0" aria-describedby="info-tooltip">
+        <svg
+          id="info-icon"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 30 30"
+          width="480px"
+          height="480px"
+        >
+          <path
+            d="M15,3C8.373,3,3,8.373,3,15c0,6.627,5.373,12,12,12s12-5.373,12-12C27,8.373,21.627,3,15,3z M16,21h-2v-7h2V21z M15,11.5 c-0.828,0-1.5-0.672-1.5-1.5s0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5S15.828,11.5,15,11.5z"
+          />
+        </svg>
+        <div id="info-tooltip" class="info-tooltip" role="tooltip"></div>
+      </div>
+      <div id="camera-icon-container" class="utility-icon-container" aria-hidden="true">
+        <img
+          id="camera-icon"
+          src="/camera-black.svg"
+          alt=""
+          loading="lazy"
         />
-      </svg>
-      <div id="info-tooltip" class="info-tooltip" role="tooltip"></div>
+      </div>
     </div>
     <div class="control-hints" role="status" aria-live="polite">
       <span><strong>Scroll</strong> to zoom</span>
@@ -216,6 +226,7 @@
 
       const infoTooltip = document.getElementById("info-tooltip");
       const infoIconContainer = document.getElementById("info-icon-container");
+      const cameraIconElement = document.getElementById("camera-icon");
       infoTooltip.innerHTML = `
         <p>Models adapted from the Allen Human Reference Atlas – 3D (2020), Version 1.0.0.</p>
         <p><strong>Dataset citation:</strong></p>
@@ -860,6 +871,22 @@
         return window.__neuronavDarkMode__;
       }
 
+      function updateCameraIconAppearance(useDarkBackground) {
+        if (!cameraIconElement) {
+          return;
+        }
+
+        const nextSrc = useDarkBackground
+          ? "/camera-white.svg"
+          : "/camera-black.svg";
+
+        if (cameraIconElement.getAttribute("src") !== nextSrc) {
+          cameraIconElement.setAttribute("src", nextSrc);
+        }
+      }
+
+      updateCameraIconAppearance(getDarkModeState());
+
       function updateViewportSettings(partialSettings, options = {}) {
         viewportSettings = { ...viewportSettings, ...partialSettings };
         if (!options.skipSave) {
@@ -889,15 +916,17 @@
       function applyDarkModeSetting(enableDark, options = {}) {
         const shouldUseDarkBackground = Boolean(enableDark);
         const currentDarkMode = getDarkModeState();
+        let normalizedDarkMode;
 
         if (shouldUseDarkBackground !== currentDarkMode) {
           const updatedDarkMode = updateBackground();
-          setDarkModeState(updatedDarkMode);
-          updateControlHintsColor(updatedDarkMode);
+          normalizedDarkMode = setDarkModeState(updatedDarkMode);
         } else {
-          setDarkModeState(shouldUseDarkBackground);
-          updateControlHintsColor(shouldUseDarkBackground);
+          normalizedDarkMode = setDarkModeState(shouldUseDarkBackground);
         }
+
+        updateControlHintsColor(normalizedDarkMode);
+        updateCameraIconAppearance(normalizedDarkMode);
 
         updateArrowFill();
         updateViewportSettings(

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -771,17 +771,38 @@ input:checked + .checkbox-button:before {
 	display: flex;
 }
 
-#info-icon-container {
-        position: absolute;
+#utility-icon-bar {
+        position: fixed;
+        left: 0;
+        right: 0;
         bottom: 2%;
-        left: 1%;
+
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0 1.5rem 0 1%;
+
+        pointer-events: none;
+        z-index: 5;
+}
+
+.utility-icon-container {
+        position: relative;
 
         width: 30px;
         height: 30px;
 
-        display: flex;
-        justify-content: center;
+        display: inline-flex;
         align-items: center;
+        justify-content: center;
+
+        pointer-events: auto;
+}
+
+#info-icon-container {
+        margin-left: 0;
+
         outline: none;
 }
 
@@ -792,11 +813,11 @@ input:checked + .checkbox-button:before {
 
 .info-tooltip {
         position: absolute;
-        top: -0.25rem;
-        left: 150%;
+        right: 0;
+        bottom: calc(100% + 0.5rem);
         z-index: 99;
-        transform: translateX(-8%) translateY(-100%) scale(0);
-        transform-origin: bottom left;
+        transform: scale(0);
+        transform-origin: bottom right;
         transition: 150ms transform;
         background: var(--grey-tertiary);
         color: var(--white);
@@ -813,12 +834,12 @@ input:checked + .checkbox-button:before {
 #info-icon-container:hover .info-tooltip,
 #info-icon-container:focus .info-tooltip,
 #info-icon-container:focus-within .info-tooltip {
-        transform: translateX(-8%) translateY(-100%) scale(1);
+        transform: scale(1);
         pointer-events: auto;
 }
 
 .info-tooltip.visible {
-        transform: translateX(-8%) translateY(-100%) scale(1);
+        transform: scale(1);
         pointer-events: auto;
 }
 
@@ -836,11 +857,19 @@ input:checked + .checkbox-button:before {
         word-break: break-word;
 }
 
-#info-icon { 
+#info-icon {
         width: 30px;
         height: 30px;
 
         fill: var(--grey-tertiary);
+}
+
+#camera-icon {
+        width: 100%;
+        height: 100%;
+
+        display: block;
+        object-fit: contain;
 }
 
 .control-hints {


### PR DESCRIPTION
## Summary
- add a camera utility icon next to the info icon using shared inline-flex styling
- swap the camera icon between white and black assets in response to dark background toggles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3d072414c8331beb1cca7bf7ad98e