### PR TITLE
Adjust info icon styling for dark mode

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -230,6 +230,7 @@
 
       const infoTooltip = document.getElementById("info-tooltip");
       const infoIconContainer = document.getElementById("info-icon-container");
+      const infoIconElement = document.getElementById("info-icon");
       const cameraIconContainer = document.getElementById("camera-icon-container");
       const cameraIconElement = document.getElementById("camera-icon");
       infoTooltip.innerHTML = `
@@ -937,6 +938,17 @@
         return window.__neuronavDarkMode__;
       }
 
+      function updateInfoIconAppearance(useDarkBackground) {
+        if (!infoIconElement) {
+          return;
+        }
+
+        infoIconElement.classList.toggle(
+          "info-icon--dark",
+          Boolean(useDarkBackground),
+        );
+      }
+
       function updateCameraIconAppearance(useDarkBackground) {
         if (!cameraIconElement || !cameraIconContainer) {
           return;
@@ -960,6 +972,7 @@
         }
       }
 
+      updateInfoIconAppearance(getDarkModeState());
       updateCameraIconAppearance(getDarkModeState());
 
       function updateViewportSettings(partialSettings, options = {}) {
@@ -1001,6 +1014,7 @@
         }
 
         updateControlHintsColor(normalizedDarkMode);
+        updateInfoIconAppearance(normalizedDarkMode);
         updateCameraIconAppearance(normalizedDarkMode);
 
         updateArrowFill();

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -905,6 +905,10 @@ input:checked + .checkbox-button:before {
         fill: var(--grey-tertiary);
 }
 
+#info-icon.info-icon--dark {
+        fill: var(--white);
+}
+
 #camera-icon {
         width: 70%;
         height: 70%;


### PR DESCRIPTION
## Summary
- capture the info icon element and add a helper to toggle its dark mode styling
- invoke the helper during initialization and whenever dark mode settings change
- add CSS to render the info icon in white on dark backgrounds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3e4d38ff88331ac1dac1a845642d9